### PR TITLE
Duplicate Rules Setup

### DIFF
--- a/force-app/main/default/duplicateRules/Attendee__c.Attendee_Duplicate_Rule.duplicateRule-meta.xml
+++ b/force-app/main/default/duplicateRules/Attendee__c.Attendee_Duplicate_Rule.duplicateRule-meta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DuplicateRule xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <actionOnInsert>Block</actionOnInsert>
+    <actionOnUpdate>Block</actionOnUpdate>
+    <alertText>Use one of these records? There is already an existing records with the same Name, Email &amp; Phone.</alertText>
+    <description>User can not create duplicate Attendee with the Same Name, Email &amp; Phone</description>
+    <duplicateRuleFilter xsi:nil="true"/>
+    <duplicateRuleMatchRules>
+        <matchRuleSObjectType>Attendee__c</matchRuleSObjectType>
+        <matchingRule>Attendee_Matching_Rule</matchingRule>
+        <objectMapping xsi:nil="true"/>
+    </duplicateRuleMatchRules>
+    <isActive>true</isActive>
+    <masterLabel>Attendee Duplicate Rule</masterLabel>
+    <securityOption>EnforceSharingRules</securityOption>
+    <sortOrder>1</sortOrder>
+</DuplicateRule>

--- a/force-app/main/default/duplicateRules/Event_Organizer__c.Event_Organizer_Duplicate_Rule.duplicateRule-meta.xml
+++ b/force-app/main/default/duplicateRules/Event_Organizer__c.Event_Organizer_Duplicate_Rule.duplicateRule-meta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DuplicateRule xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <actionOnInsert>Block</actionOnInsert>
+    <actionOnUpdate>Block</actionOnUpdate>
+    <alertText>Use one of these records? There is already an existing record with the same Email &amp; Phone.</alertText>
+    <description>User can not create duplicate Event Organizer record with the same Email &amp; Phone.</description>
+    <duplicateRuleFilter xsi:nil="true"/>
+    <duplicateRuleMatchRules>
+        <matchRuleSObjectType>Event_Organizer__c</matchRuleSObjectType>
+        <matchingRule>Event_Organizer_Matching_Rule</matchingRule>
+        <objectMapping xsi:nil="true"/>
+    </duplicateRuleMatchRules>
+    <isActive>true</isActive>
+    <masterLabel>Event Organizer Duplicate Rule</masterLabel>
+    <securityOption>EnforceSharingRules</securityOption>
+    <sortOrder>1</sortOrder>
+</DuplicateRule>

--- a/force-app/main/default/duplicateRules/Speaker__c.Speaker_Duplicate_Rule.duplicateRule-meta.xml
+++ b/force-app/main/default/duplicateRules/Speaker__c.Speaker_Duplicate_Rule.duplicateRule-meta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DuplicateRule xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <actionOnInsert>Block</actionOnInsert>
+    <actionOnUpdate>Block</actionOnUpdate>
+    <alertText>Use one of these records? There is already an existing records wiht the same Email &amp; Phone.</alertText>
+    <description>User can not create duplicate Speaker record with the same Email &amp; Phone</description>
+    <duplicateRuleFilter xsi:nil="true"/>
+    <duplicateRuleMatchRules>
+        <matchRuleSObjectType>Speaker__c</matchRuleSObjectType>
+        <matchingRule>Speaker_Matching_Rule</matchingRule>
+        <objectMapping xsi:nil="true"/>
+    </duplicateRuleMatchRules>
+    <isActive>true</isActive>
+    <masterLabel>Speaker Duplicate Rule</masterLabel>
+    <securityOption>EnforceSharingRules</securityOption>
+    <sortOrder>1</sortOrder>
+</DuplicateRule>

--- a/force-app/main/default/matchingRules/Attendee__c.matchingRule-meta.xml
+++ b/force-app/main/default/matchingRules/Attendee__c.matchingRule-meta.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MatchingRules xmlns="http://soap.sforce.com/2006/04/metadata">
+    <matchingRules>
+        <fullName>Attendee_Matching_Rule</fullName>
+        <description>User can not create duplicate attendee with the Same Name, Email &amp; Phone</description>
+        <label>Attendee Matching Rule</label>
+        <matchingRuleItems>
+            <blankValueBehavior>NullNotAllowed</blankValueBehavior>
+            <fieldName>Name</fieldName>
+            <matchingMethod>Exact</matchingMethod>
+        </matchingRuleItems>
+        <matchingRuleItems>
+            <blankValueBehavior>NullNotAllowed</blankValueBehavior>
+            <fieldName>Email__c</fieldName>
+            <matchingMethod>Exact</matchingMethod>
+        </matchingRuleItems>
+        <matchingRuleItems>
+            <blankValueBehavior>NullNotAllowed</blankValueBehavior>
+            <fieldName>Phone__c</fieldName>
+            <matchingMethod>Exact</matchingMethod>
+        </matchingRuleItems>
+        <ruleStatus>Active</ruleStatus>
+    </matchingRules>
+</MatchingRules>

--- a/force-app/main/default/matchingRules/Event_Organizer__c.matchingRule-meta.xml
+++ b/force-app/main/default/matchingRules/Event_Organizer__c.matchingRule-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MatchingRules xmlns="http://soap.sforce.com/2006/04/metadata">
+    <matchingRules>
+        <fullName>Event_Organizer_Matching_Rule</fullName>
+        <description>User can not create duplicate Event Organizer record with the same Email &amp; Phone</description>
+        <label>Event Organizer Matching Rule</label>
+        <matchingRuleItems>
+            <blankValueBehavior>NullNotAllowed</blankValueBehavior>
+            <fieldName>Email__c</fieldName>
+            <matchingMethod>Exact</matchingMethod>
+        </matchingRuleItems>
+        <matchingRuleItems>
+            <blankValueBehavior>NullNotAllowed</blankValueBehavior>
+            <fieldName>Phone__c</fieldName>
+            <matchingMethod>Exact</matchingMethod>
+        </matchingRuleItems>
+        <ruleStatus>Active</ruleStatus>
+    </matchingRules>
+</MatchingRules>

--- a/force-app/main/default/matchingRules/Speaker__c.matchingRule-meta.xml
+++ b/force-app/main/default/matchingRules/Speaker__c.matchingRule-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MatchingRules xmlns="http://soap.sforce.com/2006/04/metadata">
+    <matchingRules>
+        <fullName>Speaker_Matching_Rule</fullName>
+        <description>User can not create duplicate speaker record with the same Email &amp; Phone</description>
+        <label>Speaker Matching Rule</label>
+        <matchingRuleItems>
+            <blankValueBehavior>NullNotAllowed</blankValueBehavior>
+            <fieldName>Email__c</fieldName>
+            <matchingMethod>Exact</matchingMethod>
+        </matchingRuleItems>
+        <matchingRuleItems>
+            <blankValueBehavior>NullNotAllowed</blankValueBehavior>
+            <fieldName>Phone__c</fieldName>
+            <matchingMethod>Exact</matchingMethod>
+        </matchingRuleItems>
+        <ruleStatus>Active</ruleStatus>
+    </matchingRules>
+</MatchingRules>


### PR DESCRIPTION
#1 Speaker Object
User can not create duplicate Speaker record with the same Email & Phone.
#2 Attendee Object
User can not Create duplicate Attendee with the Same Name, Email & Phone.
#3 Event Organizer Objet
User can not create duplicate Event Organize record with the same Email & Phone.
